### PR TITLE
REXPaint allows editing up to 9 layers as of v1.03

### DIFF
--- a/src/console_rexpaint.c
+++ b/src/console_rexpaint.c
@@ -322,7 +322,7 @@ bool TCOD_console_save_xp(
  *  This function can save any number of layers with multiple
  *  different sizes.
  *
- *  The REXPaint tool only supports files with up to 4 layers where
+ *  The REXPaint tool only supports files with up to 9 layers where
  *  all layers are the same size.
  */
 bool TCOD_console_list_save_xp(


### PR DESCRIPTION
Eventually unlimited layers will be editable, but that won't come until 2.0.