### PR TITLE
Link shared library against pthread library

### DIFF
--- a/build/autotools/Makefile.am
+++ b/build/autotools/Makefile.am
@@ -22,8 +22,8 @@ lib_LTLIBRARIES = libtcod.la
 include $(srcdir)/collected_files.am
 
 libtcod_la_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
-libtcod_la_LDFLAGS = $(AM_LDFLAGS) -version-info $(SOVERSION)
-libtcod_la_LIBADD = $(PTHREAD_LIBS)
+libtcod_la_LDFLAGS = $(AM_LDFLAGS) -version-info $(SOVERSION) -lpthread
+libtcod_la_LIBADD = $(PTHREAD_LIBS) -lpthread
 
 if ENABLE_SAMPLES
 noinst_PROGRAMS = samples_c samples_cpp


### PR DESCRIPTION
Hi,

for some reason, the libtcod shared library currently is not linked against libpthread, even though it uses some of its symbols.

You can check this for yourself by building `libtcod.so.1` using the Autotools build files and then running

```
objdump -x libtcod.so.1 | grep NEEDED
```

And you will notice that `libpthread.so.0` is not in this list. With this pull request, the shared library will be linked against libpthread.

Best regards,
Fabian