### PR TITLE
Migrate build scripts

### DIFF
--- a/build/autotools/collect_files.py
+++ b/build/autotools/collect_files.py
@@ -7,9 +7,8 @@ This script will update the collected_files.md file.
 
 import os
 
-import re
-
 BANNER = '# This file is automatically updated by running collect_files.py'
+
 
 def collect():
     """Return an iterator of AutoMake commands.
@@ -33,14 +32,15 @@ def collect():
         source_files.extend('/'.join([curpath, f]) for f in files
                             if f.endswith('.c') or f.endswith('.cpp'))
         if '/.' in curpath[5:]:
-            continue # Skip hidden directories.
+            continue  # Skip hidden directories.
         if not include_files:
             continue
-        yield('%sdir = %s' % (include_name, include_dir))
-        yield('%s_HEADERS = \\\n\t%s' % (include_name,
-                                   ' \\\n\t'.join(include_files)))
-        yield('')
-    yield('libtcod_la_SOURCES = \\\n\t%s' % (' \\\n\t'.join(source_files),))
+        yield ('%sdir = %s' % (include_name, include_dir))
+        yield ('%s_HEADERS = \\\n\t%s' % (include_name,
+                                          ' \\\n\t'.join(include_files)))
+        yield ('')
+    yield ('libtcod_la_SOURCES = \\\n\t%s' % (' \\\n\t'.join(source_files),))
+
 
 def main():
     with open('collected_files.am', 'w') as file:
@@ -48,6 +48,7 @@ def main():
         file.write('\n\n')
         file.write('\n'.join(collect()))
         file.write('\n')
+
 
 if __name__ == '__main__':
     main()

--- a/build/autotools/collect_files.py
+++ b/build/autotools/collect_files.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Writes out the source and include files needed for AutoTools.
 

--- a/build/autotools/get_version.py
+++ b/build/autotools/get_version.py
@@ -5,15 +5,15 @@
     The --so flag can be used to get the library version number instead.
 """
 
-import sys
-
 import io
 import re
+import sys
 
 RE_MAJOR = '.*#define TCOD_MAJOR_VERSION *([0-9]+)'
 RE_MINOR = '.*#define TCOD_MINOR_VERSION *([0-9]+)'
 RE_PATCH = '.*#define TCOD_PATCHLEVEL *([0-9]+)'
 RE_VERSION = RE_MAJOR + RE_MINOR + RE_PATCH
+
 
 def main():
     with io.open('../../src/libtcod/version.h', encoding='utf-8') as f:
@@ -23,6 +23,7 @@ def main():
         print('{major}:{minor}'.format(**locals()))
     else:
         print('{major}.{minor}.{patch}'.format(**locals()))
+
 
 if __name__ == '__main__':
     main()

--- a/build/autotools/get_version.py
+++ b/build/autotools/get_version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
     Print the version number for libtcod.
 


### PR DESCRIPTION
Checked the python code base under build/autotools/. Both are running fine. Changed the comments from python to python3 and pylinted the code as per Python3.7 standards.