### PR TITLE
Allow reading/writing RNG state to zip

### DIFF
--- a/src/libtcod/mersenne.hpp
+++ b/src/libtcod/mersenne.hpp
@@ -392,6 +392,16 @@ In these cases, the selected mean will appear with the lowest frequency.
 		inline int diceRoll (TCOD_dice_t dice) { return TCOD_random_dice_roll(data,dice); }
 		inline int diceRoll (const char * s) { return TCOD_random_dice_roll(data,TCOD_random_dice_new(s)); }
 
+		TCODRandom(TCOD_random_t mersenne) : data(mersenne) {}
+
+  		TCOD_Random* get_data() noexcept
+  		{
+  		  return data;
+  		}
+  		const TCOD_Random* get_data() const noexcept
+  		{
+  		  return data;
+  		}
 	protected :
 		friend class TCODLIB_API TCODNoise;
 		friend class TCODLIB_API TCODHeightMap;

--- a/src/libtcod/mersenne.hpp
+++ b/src/libtcod/mersenne.hpp
@@ -394,14 +394,14 @@ In these cases, the selected mean will appear with the lowest frequency.
 
 		TCODRandom(TCOD_random_t mersenne) : data(mersenne) {}
 
-  		TCOD_Random* get_data() noexcept
-  		{
-  		  return data;
-  		}
-  		const TCOD_Random* get_data() const noexcept
-  		{
-  		  return data;
-  		}
+		TCOD_Random* get_data() noexcept
+		{
+			return data;
+		}
+		const TCOD_Random* get_data() const noexcept
+		{
+			return data;
+		}
 	protected :
 		friend class TCODLIB_API TCODNoise;
 		friend class TCODLIB_API TCODHeightMap;

--- a/src/libtcod/mersenne_types.h
+++ b/src/libtcod/mersenne_types.h
@@ -32,6 +32,7 @@
 #ifndef _TCOD_RANDOM_TYPES_H
 #define _TCOD_RANDOM_TYPES_H
 struct TCOD_Random;
+typedef struct TCOD_Random TCOD_Random;
 typedef struct TCOD_Random *TCOD_random_t;
 
 /* dice roll */

--- a/src/libtcod/zip.cpp
+++ b/src/libtcod/zip.cpp
@@ -77,6 +77,11 @@ void TCODZip::putConsole(const TCODConsole *val)
   TCOD_zip_put_console(data, val->get_data());
 }
 
+void TCODZip::putRandom(const TCODRandom *val)
+{
+	TCOD_zip_put_random(data, val->get_data());
+}
+
 int TCODZip::saveToFile(const char *filename) {
 	return TCOD_zip_save_to_file(data,filename);
 }
@@ -115,6 +120,10 @@ TCODImage *TCODZip::getImage() {
 
 TCODConsole *TCODZip::getConsole() {
 	return new TCODConsole(TCOD_zip_get_console(data));
+}
+
+TCODRandom *TCODZip::getRandom() {
+	return new TCODRandom(TCOD_zip_get_random(data));
 }
 
 uint32_t TCODZip::getCurrentBytes() const {

--- a/src/libtcod/zip.h
+++ b/src/libtcod/zip.h
@@ -36,6 +36,7 @@
 #include "color.h"
 #include "console_types.h"
 #include "image.h"
+#include "mersenne.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -54,6 +55,7 @@ TCODLIB_API void TCOD_zip_put_string(TCOD_zip_t zip, const char *val);
 TCODLIB_API void TCOD_zip_put_color(TCOD_zip_t zip, const TCOD_color_t val);
 TCODLIB_API void TCOD_zip_put_image(TCOD_zip_t zip, const TCOD_image_t val);
 TCODLIB_API void TCOD_zip_put_console(TCOD_zip_t zip, const TCOD_Console* val);
+TCODLIB_API void TCOD_zip_put_random(TCOD_zip_t zip, const TCOD_Random *val);
 TCODLIB_API void TCOD_zip_put_data(TCOD_zip_t zip, int nbBytes, const void *data);
 TCODLIB_API uint32_t TCOD_zip_get_current_bytes(TCOD_zip_t zip);
 TCODLIB_API int TCOD_zip_save_to_file(TCOD_zip_t zip, const char *filename);
@@ -67,6 +69,7 @@ TCODLIB_API const char *TCOD_zip_get_string(TCOD_zip_t zip);
 TCODLIB_API TCOD_color_t TCOD_zip_get_color(TCOD_zip_t zip);
 TCODLIB_API TCOD_image_t TCOD_zip_get_image(TCOD_zip_t zip);
 TCODLIB_API TCOD_console_t TCOD_zip_get_console(TCOD_zip_t zip);
+TCODLIB_API TCOD_random_t TCOD_zip_get_random(TCOD_zip_t zip);
 TCODLIB_API int TCOD_zip_get_data(TCOD_zip_t zip, int nbBytes, void *data);
 TCODLIB_API uint32_t TCOD_zip_get_remaining_bytes(TCOD_zip_t zip);
 TCODLIB_API void TCOD_zip_skip_bytes(TCOD_zip_t zip, uint32_t nbBytes);

--- a/src/libtcod/zip.hpp
+++ b/src/libtcod/zip.hpp
@@ -35,6 +35,7 @@
 #include "color.hpp"
 #include "console.hpp"
 #include "image.hpp"
+#include "mersenne.hpp"
 #include "zip.h"
 /**
  @PageName zip
@@ -161,6 +162,16 @@ public :
 
 	/**
 	@PageName zip_put
+	@FuncTitle Putting a random number generator state in the buffer
+	@Cpp void TCODZip::putRandom(const TCOD_random_t val)
+	@C void TCOD_zip_put_random(TCOD_zip_t zip, const TCOD_random_t val)
+	@Param zip	In the C version, the buffer handler, returned by the constructor.
+	@Param val	An RNG state to store in the buffer
+	*/
+	void putRandom(const TCODRandom *val);
+
+	/**
+	@PageName zip_put
 	@FuncTitle Putting some custom data in the buffer
 	@Cpp void TCODZip::putData(int nbBytes, const void *data)
 	@C void TCOD_zip_put_data(TCOD_zip_t zip, int nbBytes, const void *data)
@@ -284,6 +295,15 @@ public :
 	@Param zip	In the C version, the buffer handler, returned by the constructor.
 	*/
 	TCODConsole *getConsole();
+
+	/**
+	@PageName zip_load
+	@FuncTitle Reading a random number generator state from the buffer
+	@Cpp TCODConsole *TCODZip::getRandom()
+	@C TCOD_random_t TCOD_zip_get_random(TCOD_zip_t zip)
+	@Param zip	In the C version, the buffer handler, returned by the constructor.
+	*/
+	TCODRandom *getRandom();
 
 	/**
 	@PageName zip_load

--- a/src/libtcod/zip.hpp
+++ b/src/libtcod/zip.hpp
@@ -299,7 +299,7 @@ public :
 	/**
 	@PageName zip_load
 	@FuncTitle Reading a random number generator state from the buffer
-	@Cpp TCODConsole *TCODZip::getRandom()
+	@Cpp TCODRandom *TCODZip::getRandom()
 	@C TCOD_random_t TCOD_zip_get_random(TCOD_zip_t zip)
 	@Param zip	In the C version, the buffer handler, returned by the constructor.
 	*/

--- a/src/libtcod/zip_c.c
+++ b/src/libtcod/zip_c.c
@@ -166,9 +166,9 @@ void TCOD_zip_put_console(TCOD_zip_t zip, const TCOD_Console* val)
 }
 
 void TCOD_zip_put_random(TCOD_zip_t zip, const TCOD_Random *val) {
-    size_t s = sizeof(*val);
-    TCOD_zip_put_int(zip, s);
-    TCOD_zip_put_data(zip, s, val);
+	size_t s = sizeof(*val);
+	TCOD_zip_put_int(zip, s);
+	TCOD_zip_put_data(zip, s, val);
 }
 
 int TCOD_zip_save_to_file(TCOD_zip_t pzip, const char *filename) {
@@ -372,8 +372,8 @@ TCODLIB_API TCOD_random_t TCOD_zip_get_random(TCOD_zip_t zip)
 {
 	TCOD_random_t ret;
 	size_t s = TCOD_zip_get_int(zip);
-    ret = (TCOD_random_t)malloc(s);
-    TCOD_zip_get_data(zip, s, ret);
+	ret = (TCOD_random_t)malloc(s);
+	TCOD_zip_get_data(zip, s, ret);
 	return ret;
 }
 

--- a/src/libtcod/zip_c.c
+++ b/src/libtcod/zip_c.c
@@ -166,7 +166,7 @@ void TCOD_zip_put_console(TCOD_zip_t zip, const TCOD_Console* val)
 }
 
 void TCOD_zip_put_random(TCOD_zip_t zip, const TCOD_Random *val) {
-	size_t s = sizeof(*val);
+	int s = (int)sizeof(*val);
 	TCOD_zip_put_int(zip, s);
 	TCOD_zip_put_data(zip, s, val);
 }

--- a/src/libtcod/zip_c.c
+++ b/src/libtcod/zip_c.c
@@ -165,6 +165,12 @@ void TCOD_zip_put_console(TCOD_zip_t zip, const TCOD_Console* val)
 	}
 }
 
+void TCOD_zip_put_random(TCOD_zip_t zip, const TCOD_Random *val) {
+    size_t s = sizeof(*val);
+    TCOD_zip_put_int(zip, s);
+    TCOD_zip_put_data(zip, s, val);
+}
+
 int TCOD_zip_save_to_file(TCOD_zip_t pzip, const char *filename) {
 	zip_data_t *zip=(zip_data_t *)pzip;
 	gzFile f=gzopen(filename,"wb");
@@ -359,6 +365,15 @@ TCOD_console_t TCOD_zip_get_console(TCOD_zip_t pzip) {
 			TCOD_console_set_char_background(ret, x,y,TCOD_zip_get_color(pzip), TCOD_BKGND_SET);
 		}
 	}
+	return ret;
+}
+
+TCODLIB_API TCOD_random_t TCOD_zip_get_random(TCOD_zip_t zip)
+{
+	TCOD_random_t ret;
+	size_t s = TCOD_zip_get_int(zip);
+    ret = (TCOD_random_t)malloc(s);
+    TCOD_zip_get_data(zip, s, ret);
 	return ret;
 }
 


### PR DESCRIPTION
This adds `TCOD_zip_put_random` and `TCOD_zip_get_random` functions to the zip API. It was useful in my project to be able to save/load RNG state. This makes it possible with two function calls and no need to include `libtcod_int.h`.

This is implemented using the existing `TCOD_zip_put_data` and `TCOD_zip_get_data` functions.