### PR TITLE
nodiscard attribute in correct position

### DIFF
--- a/src/libtcod/sys.h
+++ b/src/libtcod/sys.h
@@ -52,7 +52,7 @@ TCODLIB_API float TCOD_sys_get_last_frame_length(void);
 
 TCODLIB_API void TCOD_sys_save_screenshot(const char *filename);
 TCODLIB_API void TCOD_sys_force_fullscreen_resolution(int width, int height);
-TCODLIB_API int TCOD_NODISCARD TCOD_sys_set_renderer(TCOD_renderer_t renderer);
+TCODLIB_API TCOD_NODISCARD int TCOD_sys_set_renderer(TCOD_renderer_t renderer);
 TCODLIB_API TCOD_renderer_t TCOD_sys_get_renderer(void);
 TCODLIB_API void TCOD_sys_get_current_resolution(int *w, int *h);
 TCODLIB_API void TCOD_sys_get_fullscreen_offsets(int *offx, int *offy);


### PR DESCRIPTION
Fix warning regarding ignored attribute when compiling with g++ using `-std=c++17` or higher

```
src/libtcod/config.h:105:24: warning: attribute ignored [-Wattributes]
src/libtcod/config.h:105:24: note: an attribute that appertains to a type-specifier is ignored
src/libtcod/sys.h:55:17: note: in expansion of macro ‘TCOD_NODISCARD’
   55 | TCODLIB_API int TCOD_NODISCARD TCOD_sys_set_renderer(TCOD_renderer_t renderer);
```
