### PR TITLE
gui: replace deprecated printEx with printf

### DIFF
--- a/samples/hmtool/hmtool.cpp
+++ b/samples/hmtool/hmtool.cpp
@@ -140,8 +140,8 @@ void render() {
 	sprintf(maxZTxt,"max z    : %.2f",mapmax);
 	sprintf(seedTxt,"seed     : %X",seed);
 	float landProportion=100.0f - 100.0f*backup.countCells(0.0f,sandHeight) / (hm->w*hm->h);
-	sprintf(landMassTxt,"landMass : %d %%%%",(int)landProportion);
-	if ( ! isNormalized ) TCODConsole::root->printEx(HM_WIDTH/2,HM_HEIGHT-1,TCOD_BKGND_NONE,TCOD_CENTER,"the map is not normalized !");
+	sprintf(landMassTxt,"landMass : %d %%",(int)landProportion);
+	if ( ! isNormalized ) TCODConsole::root->printf(HM_WIDTH/2,HM_HEIGHT-1,TCOD_BKGND_NONE,TCOD_CENTER,"the map is not normalized !");
 	// message
 	msgDelay-=TCODSystem::getLastFrameLength();
 	if ( msg[0] != 0 && msgDelay > 0.0f ) {

--- a/samples/hmtool/operation.cpp
+++ b/samples/hmtool/operation.cpp
@@ -10,7 +10,7 @@ const char *Operation::names[]= {
 	"+fbm",
 	"*fbm",
 	"hill",
-	"\x18\x19 z",
+	"\u2191\u2193 z",
 	"smooth",
 	"rain",
 	"lerp fbm",

--- a/src/libtcod/console.hpp
+++ b/src/libtcod/console.hpp
@@ -1038,6 +1038,7 @@ public :
 	@Param fmt if NULL, the function only draws a rectangle.
 		Else, printf-like format string, eventually followed by parameters. You can use control codes to change the colors inside the string.
 	*/
+	TCODLIB_FORMAT(8, 9)
 	void printFrame(int x,int y,int w,int h, bool clear=true, TCOD_bkgnd_flag_t flag = TCOD_BKGND_DEFAULT, const char *fmt=NULL, ...);
 
 	/**

--- a/src/libtcod/gui/button.cpp
+++ b/src/libtcod/gui/button.cpp
@@ -81,9 +81,9 @@ void Button::render() {
   if (w > 0 && h > 0) { con->rect(x, y, w, h, true, TCOD_BKGND_SET); }
   if (label) {
     if (pressed && mouseIn) {
-      con->printEx(x + w / 2, y, TCOD_BKGND_NONE, TCOD_CENTER, "-%s-", label);
+      con->printf(x + w / 2, y, TCOD_BKGND_NONE, TCOD_CENTER, "-%s-", label);
     } else {
-      con->printEx(x + w / 2, y, TCOD_BKGND_NONE, TCOD_CENTER, label);
+      con->printf(x + w / 2, y, TCOD_BKGND_NONE, TCOD_CENTER, "%s", label);
     }
   }
 }

--- a/src/libtcod/gui/label.cpp
+++ b/src/libtcod/gui/label.cpp
@@ -42,7 +42,7 @@ Label::Label(int x, int y, const char *label, const char *tip)
 void Label::render() {
   con->setDefaultBackground(back);
   con->setDefaultForeground(fore);
-  con->printEx(x, y, TCOD_BKGND_NONE, TCOD_LEFT, label);
+  con->printf(x, y, TCOD_BKGND_NONE, TCOD_LEFT, "%s", label);
 }
 void Label::computeSize() {
   w = label ? static_cast<int>(strlen(label)) : 0;

--- a/src/libtcod/gui/textbox.cpp
+++ b/src/libtcod/gui/textbox.cpp
@@ -67,14 +67,14 @@ void TextBox::render() {
 	con->setDefaultBackground(back);
 	con->setDefaultForeground(fore);
 	con->rect(x,y,w,h,true,TCOD_BKGND_SET);
-	if ( label ) con->printEx(x,y,TCOD_BKGND_NONE,TCOD_LEFT,label);
+	if ( label ) con->printf(x,y,TCOD_BKGND_NONE,TCOD_LEFT, "%s", label);
 
 	con->setDefaultBackground(keyboardFocus == this ? foreFocus : fore);
 	con->setDefaultForeground(keyboardFocus == this ? backFocus : back);
 	con->rect(x+boxx,y,boxw,h,false,TCOD_BKGND_SET);
 	int len = static_cast<int>(strlen(txt) - offset);
 	if (len > boxw) len = boxw;
-	if ( txt ) con->printEx(x+boxx,y,TCOD_BKGND_NONE,TCOD_LEFT,"%.*s",len,&txt[offset]);
+	if ( txt ) con->printf(x+boxx,y,TCOD_BKGND_NONE,TCOD_LEFT,"%.*s",len,&txt[offset]);
 	if (keyboardFocus == this && blink > 0.0f) {
 		if (insert) {
 			con->setCharBackground(x+boxx+pos-offset,y,fore);

--- a/src/libtcod/gui/togglebutton.cpp
+++ b/src/libtcod/gui/togglebutton.cpp
@@ -37,11 +37,11 @@ void ToggleButton::render() {
 	con->setDefaultBackground(mouseIn ? backFocus : back);
 	con->setDefaultForeground(mouseIn ? foreFocus : fore);
 	con->rect(x,y,w,h,true,TCOD_BKGND_SET);
-	const char  check = pressed ? TCOD_CHAR_CHECKBOX_SET : TCOD_CHAR_CHECKBOX_UNSET;
+	const char* check = pressed ? "\u2611" : "\u2610";
 	if ( label ) {
-		con->printf(x,y,TCOD_BKGND_NONE,TCOD_LEFT,"%c %s", check, label);
+		con->printf(x,y,TCOD_BKGND_NONE,TCOD_LEFT,"%s %s", check, label);
 	} else {
-		con->printf(x,y,TCOD_BKGND_NONE,TCOD_LEFT,"%c", check);
+		con->printf(x,y,TCOD_BKGND_NONE,TCOD_LEFT,"%s", check);
 	}
 }
 

--- a/src/libtcod/gui/togglebutton.cpp
+++ b/src/libtcod/gui/togglebutton.cpp
@@ -37,10 +37,11 @@ void ToggleButton::render() {
 	con->setDefaultBackground(mouseIn ? backFocus : back);
 	con->setDefaultForeground(mouseIn ? foreFocus : fore);
 	con->rect(x,y,w,h,true,TCOD_BKGND_SET);
+	const char  check = pressed ? TCOD_CHAR_CHECKBOX_SET : TCOD_CHAR_CHECKBOX_UNSET;
 	if ( label ) {
-		con->printEx(x,y,TCOD_BKGND_NONE,TCOD_LEFT,"%c %s",pressed ? TCOD_CHAR_CHECKBOX_SET : TCOD_CHAR_CHECKBOX_UNSET, label);
+		con->printf(x,y,TCOD_BKGND_NONE,TCOD_LEFT,"%c %s", check, label);
 	} else {
-		con->printEx(x,y,TCOD_BKGND_NONE,TCOD_LEFT,"%c",pressed ? TCOD_CHAR_CHECKBOX_SET : TCOD_CHAR_CHECKBOX_UNSET);
+		con->printf(x,y,TCOD_BKGND_NONE,TCOD_LEFT,"%c", check);
 	}
 }
 

--- a/src/libtcod/gui/toolbar.cpp
+++ b/src/libtcod/gui/toolbar.cpp
@@ -103,7 +103,7 @@ void ToolBar::setName(const char *name) {
 void ToolBar::render() {
 	con->setDefaultBackground(back);
 	con->setDefaultForeground(fore);
-	con->printFrame(x,y,w,h,true,TCOD_BKGND_SET,name);
+	TCOD_console_printf_frame(con->get_data(), x, y, w, h, true, TCOD_BKGND_SET, "%s", name);
 	Container::render();
 }
 

--- a/src/libtcod/gui/toolbar.cpp
+++ b/src/libtcod/gui/toolbar.cpp
@@ -63,7 +63,7 @@ public :
 		con->setChar(x+w,y,TCOD_CHAR_TEEW);
 		con->setDefaultBackground(fore);
 		con->setDefaultForeground(back);
-		con->printEx(x+w/2,y,TCOD_BKGND_SET,TCOD_CENTER," %s ",txt);
+		con->printf(x+w/2,y,TCOD_BKGND_SET,TCOD_CENTER," %s ",txt);
 	}
 	char *txt;
 };


### PR DESCRIPTION
Replaces printEx functions with the printf alternatives in the gui.

came across an assertion failure when trying the sample hmtool due to it trying to draw one of the widgets off screen.

also, avoid passing in the label directly as that causes problems if it conains any % formatting characters