### PR TITLE
Change fallback font to SFNSMono.ttf on MacOSx

### DIFF
--- a/src/libtcod/tileset_fallback.c
+++ b/src/libtcod/tileset_fallback.c
@@ -48,7 +48,7 @@ TCOD_Tileset* TCOD_tileset_load_fallback_font_(int tile_width, int tile_height)
   return TCOD_load_truetype_font_(path, tile_width, tile_height);
 #elif defined(__APPLE__) // MacOS.
   return TCOD_load_truetype_font_(
-      "/System/Library/Fonts/SFCompactDisplay-Regular.otf",
+      "/System/Library/Fonts/SFNSMono.ttf",
       tile_width, tile_height);
 #elif defined(__unix__) // Linux
   FILE* pipe = popen("fc-match --format=%{file} monospace", "r");


### PR DESCRIPTION
The old font doesn't seem to exist by default anymore. SFNSMono.ttf
works, although the window results in a skewed aspect ratio and distorts
the font in fullscreen mode. I think, as a fallback font, working and
imperfect is better than not working at all.