### PR TITLE
Exclude VCS configuration files from archive generation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -130,3 +130,11 @@
 
 # OpenGL Shaders
 *.glsl* text
+
+
+# Exclude VCS configuration files from archive generation
+# https://feeding.cloud.geek.nz/posts/excluding-files-from-git-archive/
+.gitattributes export-ignore
+.gitignore export-ignore
+.hgtags export-ignore
+.hgignore export-ignore


### PR DESCRIPTION
This PR concerns the archives generated by `git archive`. In particular, the tarballs on the [releases](https://github.com/libtcod/libtcod/releases) page (which I suppose are also generated using `git archive`, although you can correct me if I'm wrong) contain files such as `.gitattributes`, which arguably don't belong into the release tarball because they are only relevant for Git.

In particular, the Debian package for libtcod is maintained in Git, and if the upstream tarball contains those VCS configuration files, it messes with our repository configuration when importing releases. Of course, we can remove these files, but an even better solution would be to not include them in the tarball generation in the first place!