### PR TITLE
Add TCOD_PUBLIC to console_drawing.h

### DIFF
--- a/src/libtcod/console_drawing.h
+++ b/src/libtcod/console_drawing.h
@@ -82,7 +82,7 @@ TCOD_PUBLIC void TCOD_console_vline(TCOD_Console* con, int x, int y, int l, TCOD
  *
  *  If `fg`,`bg` is NULL then their respective colors will not be updated.
  */
-void TCOD_console_put_rgb(
+TCOD_PUBLIC void TCOD_console_put_rgb(
     TCOD_Console* __restrict console,
     int x,
     int y,
@@ -97,7 +97,7 @@ void TCOD_console_put_rgb(
  *
  *  If `fg`,`bg` is NULL then their respective colors will not be updated.
  */
-void TCOD_console_draw_rect_rgb(
+TCOD_PUBLIC void TCOD_console_draw_rect_rgb(
     TCOD_Console* __restrict console,
     int x,
     int y,


### PR DESCRIPTION
I spent a while debugging this, and it looks like two functions in console.h (`TCOD_console_draw_rect_rgb` and `TCOD_console_put_rgb `) which seem like they should be public aren't accessible because they don't have the `TCOD_PUBLIC` type