### PR TITLE
Fix all saved BMP images being completely red

### DIFF
--- a/src/libtcod/sys_sdl_c.c
+++ b/src/libtcod/sys_sdl_c.c
@@ -1343,7 +1343,7 @@ SDL_Surface* TCOD_sys_create_bitmap(int width, int height, TCOD_color_t* buf) {
   for (x = 0; x < width; x++) {
     for (y = 0; y < height; y++) {
       SDL_Rect rect;
-      uint32_t col = SDL_MapRGB(&fmt, buf[x + y * width].r, buf[x + y * width].g, buf[x + y * width].b);
+      uint32_t col = SDL_MapRGB(bitmap->format, buf[x + y * width].r, buf[x + y * width].g, buf[x + y * width].b);
       rect.x = x;
       rect.y = y;
       rect.w = 1;


### PR DESCRIPTION
Fixes #70 
This one was a surprisingly tough one to fix. Not because the fix is hard, but because it was just a mess of functions and libraries. After realizing it was this function, I realized the specific line because the SDL example for FillRect was:
```C++
SDL_FillRect(s, NULL, SDL_MapRGB(s->format, 255, 0, 0));
```
Whereas the command here was:
```C++
SDL_FillRect(bitmap, &rect, col);
```
where col was (Simplified):
```C++
SDL_MapRGB(fmt, color.r, color.g, color.b)
```
So to fix the bug, instead of passing the fmt variable to col, pass the format of the surface. 