### PR TITLE
Add arm64 support for Darwin builds.

### DIFF
--- a/buildsys/scons/README.md
+++ b/buildsys/scons/README.md
@@ -1,6 +1,6 @@
 If you need to, download Scons from http://scons.org/pages/download.html
 
-This builder automatically downloads SDL2 on Windows and Mac as needed.
+This builder automatically downloads SDL2 on Windows and Intel Macs as needed.
 On Linux you must install SDL2 'the Unix way' or by installing the libsdl2-dev
 package before running this script.
 
@@ -42,3 +42,16 @@ A packaged release can be made with the `dist` alias.
 Additional variables can be changed such as the compiler and linker flags.  The
 easiest way to change these options is by editing `config.py`.
 To see an additional list of extra variables you should run `scons -h`.
+
+## ARM64 MacOS Users
+There is experimental support for using scons to build libtcod with arm64
+support when running MacOS on an arm64 CPU.
+1. Use Homebrew or Macports to install scons - running in rosetta mode
+doesn't seem to be an issue.
+2. from ./buildsys/scons, run `scons build ARCH=arm64`.
+3. The build script will put out a compiled binary in the scons folder
+with a name that looks like `libtcod-1.16.0-alpha.15-arm64-DEBUG-macos`.
+Make sure that `arm64` is in the filename.
+
+Unfortunately `scons develop_all MODE=RELEASE ARCH=arm64` does not currently
+work due to inline assembly that is being consumed by the sample apps.

--- a/buildsys/scons/README.md
+++ b/buildsys/scons/README.md
@@ -49,9 +49,10 @@ support when running MacOS on an arm64 CPU.
 1. Use Homebrew or Macports to install scons - running in rosetta mode
 doesn't seem to be an issue.
 2. from ./buildsys/scons, run `scons build ARCH=arm64`.
-3. The build script will put out a compiled binary in the scons folder
+3. The build script will put out a compiled `libtcod` binary in the scons folder
 with a name that looks like `libtcod-1.16.0-alpha.15-arm64-DEBUG-macos`.
-Make sure that `arm64` is in the filename.
+Make sure that `arm64` is in the filename. It will also output a folder called
+`Frameworks` with a corresponding arm64 framework blob of SDL.
 
 Unfortunately `scons develop_all MODE=RELEASE ARCH=arm64` does not currently
 work due to inline assembly that is being consumed by the sample apps.

--- a/buildsys/scons/SConstruct
+++ b/buildsys/scons/SConstruct
@@ -189,7 +189,7 @@ vars.Add("LINKFLAGS", "Linker flags", "")
 
 ARCH_OPTIONS = ("x86", "x86_64")
 if sys.platform == "darwin":
-    ARCH_OPTIONS += ("x86.x86_64",)
+    ARCH_OPTIONS += ("x86.x86_64", "arm64")
 
 vars.Add(
     EnumVariable(
@@ -233,7 +233,11 @@ elif sys.platform == "darwin":
 else:
     DEPENDANCY_DIR = "./dependencies"
 vars.Add("DEPENDANCY_DIR", "Directory to cache SDL2.", DEPENDANCY_DIR)
-vars.Add("SDL2_VERSION", "SDL version to fetch. (Windows/Mac only)", "2.0.8")
+
+if sys.platform == "darwin":
+    vars.Add("SDL2_VERSION", "SDL version to fetch. (Mac Only)", "2.0.14")
+else:
+    vars.Add("SDL2_VERSION", "SDL version to fetch. (Windows)", "2.0.8")
 
 vars.Add(
     EnumVariable(
@@ -321,8 +325,12 @@ if sys.platform != "darwin":
     # Removing the lib prefix on Mac causes a link failure.
     env.Replace(LIBPREFIX="", SHLIBPREFIX="")
 
-env["SDL_ARCH"] = "x86" if env["ARCH"] == "x86" else "x64"
-env["SDL_MINGW_ARCH"] = "i686" if env["SDL_ARCH"] == "x86" else "x86_64"
+if env["ARCH"] == "arm64":
+    env["SDL_ARCH"] = "arm64"
+    env["SDL_MINGW_ARCH"] = "arm64"
+else:
+    env["SDL_ARCH"] = "x86" if env["ARCH"] == "x86" else "x64"
+    env["SDL_MINGW_ARCH"] = "i686" if env["SDL_ARCH"] == "x86" else "x86_64"
 
 using_msvc = env["CC"] == "cl"
 
@@ -381,6 +389,8 @@ if sys.platform == "darwin":
         OSX_FLAGS.extend(["-arch", "i386"])
     if env["ARCH"] == "x86_64" or env["ARCH"] == "x86.x86_64":
         OSX_FLAGS.extend(["-arch", "x86_64"])
+    if env["ARCH"] == "arm64":
+        OSX_FLAGS.extend(["-arch", "arm64"])
     env.Append(CCFLAGS=OSX_FLAGS, LINKFLAGS=OSX_FLAGS)
     # Only '@loader_path/' is actually needed for the release archive.
     env.Append(


### PR DESCRIPTION
## What is this?
Apple is transitioning away from the x86 instruction set and has started manufacturing Macs with arm64 CPUs.

## What does this PR do?
This PR adds support for compiling libtcod with arm64 support via `scons build ARCH=arm64` (and hopefully breaks nothing else). This will allow people to use libtcod on newer MacBooks and acts as a guide in case someone wants to add support for arm64 linux in the future.

Unfortunately `scons develop_all MODE=RELEASE ARCH=arm64` does not seem to work due to some inline assembly that is consumed in the sample apps.