### PR TITLE
Fix inline assembly error when building on M1 Mac

### DIFF
--- a/tests/catch.hpp
+++ b/tests/catch.hpp
@@ -5819,7 +5819,11 @@ namespace Catch {
 
 #ifdef CATCH_PLATFORM_MAC
 
-    #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
+     #if defined(__i386__) || defined(__x86_64__)
+        #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
+    #elif defined(__aarch64__)
+        #define CATCH_TRAP()  __asm__(".inst 0xd4200000")
+    #endif
 
 #elif defined(CATCH_PLATFORM_LINUX)
     // If we can use inline assembler, do it because this allows us to break


### PR DESCRIPTION
When compiling `libtcod` on M1 Mac using `scons develop_all MODE=RELEASE ARCH=arm64`, I got the following error:
```
g++ -o libtcod-1.16.0-alpha.15-arm64-RELEASE-macos/unittest -O3 -flto -arch arm64 -framework ApplicationServices -framework SDL2 -F./Frameworks/SDL2.framework/.. -rpath @loader_path/ -rpath @loader_path/../Frameworks -rpath /Library/Frameworks -rpath /System/Library/Frameworks libtcod-1.16.0-alpha.15-arm64-RELEASE-macos/tests/catch.o libtcod-1.16.0-alpha.15-arm64-RELEASE-macos/tests/unittest.o -Llibtcod-1.16.0-alpha.15-arm64-RELEASE-macos -L/Users/brett/git/libtcod -ltcod
<inline asm>:1:6: error: invalid token in expression
        int $3
            ^
<inline asm>:1:6: error: invalid operand
        int $3
            ^
LLVM ERROR: Error parsing inline asm

clang: error: linker command failed with exit code 1 (use -v to see invocation)
scons: *** [libtcod-1.16.0-alpha.15-arm64-RELEASE-macos/unittest] Error 1
scons: building terminated because of errors.
```

I backported ARM assembly from [upstream Catch2 repo](https://github.com/catchorg/Catch2/blob/b9853b4b356b83bb580c746c3a1f11101f9af54f/src/catch2/internal/catch_debugger.hpp#L19) and now I can compile `libtcod` on M1 Mac.