### PR TITLE
[WIP] Compile phat x86_64 + arm64 libraries via scons

### DIFF
--- a/buildsys/scons/SConstruct
+++ b/buildsys/scons/SConstruct
@@ -189,7 +189,7 @@ vars.Add("LINKFLAGS", "Linker flags", "")
 
 ARCH_OPTIONS = ("x86", "x86_64")
 if sys.platform == "darwin":
-    ARCH_OPTIONS += ("x86.x86_64", "arm64")
+    ARCH_OPTIONS += ("x86.x86_64", "arm64", "universal2")
 
 vars.Add(
     EnumVariable(
@@ -325,6 +325,9 @@ if sys.platform != "darwin":
     # Removing the lib prefix on Mac causes a link failure.
     env.Replace(LIBPREFIX="", SHLIBPREFIX="")
 
+if env["ARCH"] == "universal2":
+   env["SDL_ARCH"] = ["x64", "arm64"]
+   env["SDL_MINGW_ARCH"] = ["x86_64", "arm64"]
 if env["ARCH"] == "arm64":
     env["SDL_ARCH"] = "arm64"
     env["SDL_MINGW_ARCH"] = "arm64"
@@ -390,6 +393,9 @@ if sys.platform == "darwin":
     if env["ARCH"] == "x86_64" or env["ARCH"] == "x86.x86_64":
         OSX_FLAGS.extend(["-arch", "x86_64"])
     if env["ARCH"] == "arm64":
+        OSX_FLAGS.extend(["-arch", "arm64"])
+    if env["ARCH"] == "universal2":
+        OSX_FLAGS.extend(["-arch", "x86_64"])
         OSX_FLAGS.extend(["-arch", "arm64"])
     env.Append(CCFLAGS=OSX_FLAGS, LINKFLAGS=OSX_FLAGS)
     # Only '@loader_path/' is actually needed for the release archive.


### PR DESCRIPTION
Not sure if this actually works - need to verify when I get my Intel Mac back.
Running `scons develop_all MODE=RELEASE ARCH=apple_universal` results in no errors and spits out a binary so its either working or its ignoring the bits where I've replaced strings with lists of strings.