### PR TITLE
Tweaks to fix gl2 rendering artifacts

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -12,6 +12,9 @@ else()
     set(LINK_TCOD libtcod::libtcod)
     set(SDL2MAIN SDL2::SDL2main)
 endif()
+if(MINGW)
+    set(LINK_TCOD mingw32 "${LINK_TCOD}")
+endif()
 
 # This and KEEP_RPATHS is required to handle RPATH's on MacOS.
 if (APPLE)

--- a/src/libtcod/renderer_gl.c
+++ b/src/libtcod/renderer_gl.c
@@ -36,24 +36,182 @@
 
 #include "../vendor/glad.h"
 #include "error.h"
+
 /**
- *  Return a rectangle shaped for a tile at `x`,`y`.
+ *  Return a rectangle shaped for a tile at column `x` and row `y` of a 2D
+ *   tile atlas.
  */
 static SDL_Rect get_aligned_tile(const struct TCOD_Tileset* tileset, int x, int y) {
-  SDL_Rect tile_rect = {x * tileset->tile_width, y * tileset->tile_height, tileset->tile_width, tileset->tile_height};
+#ifndef TILE_PADDING
+  const int TILE_PADDING = 0;
+#endif
+  // account for padding by adding initial value, plus per-tile value to upper
+  //  left coordinates
+  // size needs to stay true because it determines how big of a source area is
+  //  copied
+  SDL_Rect tile_rect = {
+    TILE_PADDING + x * (tileset->tile_width  + TILE_PADDING),
+    TILE_PADDING + y * (tileset->tile_height + TILE_PADDING),
+    tileset->tile_width, tileset->tile_height};
   return tile_rect;
 }
 /**
- *  Return the rectangle for the tile at `tile_id`.
+ *  Return the rectangle containing coordinates at which tile index `tile_id`
+ *   should be placed in the atlas texture.
  */
 static SDL_Rect get_gl_atlas_tile(const struct TCOD_TilesetAtlasOpenGL* atlas, int tile_id) {
-  return get_aligned_tile(atlas->tileset, tile_id % atlas->texture_columns, tile_id / atlas->texture_columns);
+  // calculate atlas row and column, and use that to request a destination
+  //  rectangle in pixel coordinates
+  return get_aligned_tile(
+    atlas->tileset,
+    tile_id % atlas->texture_columns,
+    tile_id / atlas->texture_columns);
 }
+#ifdef TILE_PADDING
+/**
+ *  Upload padding strips to the atlas texture.
+ *
+ *  Propagates all four edges of tile into padding space.
+ */
+static void upload_gl_tile_padding(struct TCOD_TilesetAtlasOpenGL* atlas, struct TCOD_ColorRGBA* tile_top_left, SDL_Rect* dest)
+{
+  // pointer to lower left tile pixel in tileset pixel data buffer
+  struct TCOD_ColorRGBA* tile_bottom_left =
+    tile_top_left + atlas->tileset->tile_length - atlas->tileset->tile_width;
+  // pointer to upper right tile pixel in tileset pixel data buffer
+  struct TCOD_ColorRGBA* tile_top_right =
+    tile_top_left + atlas->tileset->tile_width - 1;
+  // pointer to lower right tile pixel in tileset pixel data buffer
+  struct TCOD_ColorRGBA* tile_bottom_right =
+    tile_top_left + atlas->tileset->tile_length - 1;
+
+  for (int i = 0; i < TILE_PADDING / 2; ++i)
+  {
+    // top:
+    //  to  : dest->x, dest->y - 1 - i
+    //  size: dest->w, 1
+    //  from: tile_top_left
+    glBindTexture(GL_TEXTURE_2D, atlas->texture);
+    glTexSubImage2D(
+      GL_TEXTURE_2D, 0,
+      dest->x, dest->y - 1 - i,
+      dest->w, 1,
+      GL_RGBA, GL_UNSIGNED_BYTE,
+      tile_top_left);
+    // glBindTexture(GL_TEXTURE_2D, 0);
+    // bottom:
+    //  to  : dest->x, dest->y + dest->h + i
+    //  size: dest->w, 1
+    //  from: tile_bottom_left
+    // glBindTexture(GL_TEXTURE_2D, atlas->texture);
+    glTexSubImage2D(
+      GL_TEXTURE_2D, 0,
+      dest->x, dest->y + dest->h + i,
+      dest->w, 1,
+      GL_RGBA, GL_UNSIGNED_BYTE,
+      tile_bottom_left);
+    glBindTexture(GL_TEXTURE_2D, 0);
+    // left:
+    //  to  : dest->x - 1 - i, dest->y
+    //  size: 1,               dest->h
+    //  from: tile_top_left
+    glBindTexture(GL_TEXTURE_2D, atlas->texture);
+    // to copy a vertical strip, OpenGL needs to know tileset bytes per row
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
+    glPixelStorei(GL_UNPACK_ROW_LENGTH, atlas->tileset->tile_width);
+    glTexSubImage2D(
+      GL_TEXTURE_2D, 0,
+      dest->x - 1 - i, dest->y,
+      1, dest->h,
+      GL_RGBA, GL_UNSIGNED_BYTE,
+      tile_top_left);
+    // glBindTexture(GL_TEXTURE_2D, 0);
+    // right:
+    //  to  : dest->x + dest->w + i, dest->y
+    //  size: 1,                     dest->h
+    //  from: tile_top_right
+    // glBindTexture(GL_TEXTURE_2D, atlas->texture);
+    // to copy a vertical strip, OpenGL needs to know tileset bytes per row
+    // glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+    // glPixelStorei(GL_UNPACK_ROW_LENGTH, atlas->tileset->tile_width);
+    glTexSubImage2D(
+      GL_TEXTURE_2D, 0,
+      dest->x + dest->w + i, dest->y,
+      1, dest->h,
+      GL_RGBA, GL_UNSIGNED_BYTE,
+      tile_top_right);
+    glBindTexture(GL_TEXTURE_2D, 0);
+    glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+  }
+
+  // test: fill in the padding corners by copying in the nearest tile corner
+  // this seems to help with the noise demo at least
+  for (int py = 0; py < TILE_PADDING / 2; ++py)
+  {
+    for (int px = 0; px < TILE_PADDING / 2; ++px)
+    {
+      // upper left:
+      //  to  : dest->x - 1 - px, dest->y - 1 - py
+      //  size: 1,           1
+      //  from: tile_top_left
+      glBindTexture(GL_TEXTURE_2D, atlas->texture);
+      glTexSubImage2D(
+        GL_TEXTURE_2D, 0,
+        dest->x - 1 - px, dest->y - 1 - py,
+        1, 1,
+        GL_RGBA, GL_UNSIGNED_BYTE,
+        tile_top_left);
+      // glBindTexture(GL_TEXTURE_2D, 0);
+      // upper right:
+      //  to  : dest->x + dest->w + px, dest->y - 1 - py
+      //  size: 1,                 1
+      //  from: tile_top_right
+      // glBindTexture(GL_TEXTURE_2D, atlas->texture);
+      glTexSubImage2D(
+        GL_TEXTURE_2D, 0,
+        dest->x + dest->w + px, dest->y - 1 - py,
+        1, 1,
+        GL_RGBA, GL_UNSIGNED_BYTE,
+        tile_top_right);
+      // glBindTexture(GL_TEXTURE_2D, 0);
+      // lower left:
+      //  to  : dest->x - 1 - px, dest->y + dest->h + py
+      //  size: 1,           1
+      //  from: tile_bottom_left
+      // glBindTexture(GL_TEXTURE_2D, atlas->texture);
+      glTexSubImage2D(
+        GL_TEXTURE_2D, 0,
+        dest->x - 1 - px, dest->y + dest->h + py,
+        1, 1,
+        GL_RGBA, GL_UNSIGNED_BYTE,
+        tile_bottom_left);
+      // glBindTexture(GL_TEXTURE_2D, 0);
+      // lower right:
+      //  to  : dest->x + dest->w + px, dest->y + dest->h + py
+      //  size: 1,                 1
+      //  from: tile_bottom_right
+      // glBindTexture(GL_TEXTURE_2D, atlas->texture);
+      glTexSubImage2D(
+        GL_TEXTURE_2D, 0,
+        dest->x + dest->w + px, dest->y + dest->h + py,
+        1, 1,
+        GL_RGBA, GL_UNSIGNED_BYTE,
+        tile_bottom_right);
+      glBindTexture(GL_TEXTURE_2D, 0);
+    }
+  }
+}
+#endif
 /**
  *  Upload a single tile to the atlas texture.
  */
 static int upload_gl_tile(struct TCOD_TilesetAtlasOpenGL* atlas, int tile_id) {
   SDL_Rect dest = get_gl_atlas_tile(atlas, tile_id);
+  struct TCOD_ColorRGBA* tile_origin = atlas->tileset->pixels + (tile_id * atlas->tileset->tile_length);
+#ifdef TILE_PADDING
+  // also repeat edge pixels into the padding space
+  upload_gl_tile_padding(atlas, tile_origin, &dest);
+#endif
   glBindTexture(GL_TEXTURE_2D, atlas->texture);
   glTexSubImage2D(
       GL_TEXTURE_2D,
@@ -64,31 +222,49 @@ static int upload_gl_tile(struct TCOD_TilesetAtlasOpenGL* atlas, int tile_id) {
       dest.h,
       GL_RGBA,
       GL_UNSIGNED_BYTE,
-      atlas->tileset->pixels + (tile_id * atlas->tileset->tile_length));
+      tile_origin);
   glBindTexture(GL_TEXTURE_2D, 0);
   return 0;
 }
 /**
  *  Setup a atlas texture and upload the tileset graphics.
+ *
+ *  This will be a square texture whose dimensions are a power of 2, of
+ *   sufficient size to hold all of the tiles.
  */
 TCOD_NODISCARD
 static int prepare_gl_atlas(struct TCOD_TilesetAtlasOpenGL* atlas) {
+#ifndef TILE_PADDING
+  const int TILE_PADDING = 0;
+#endif
   GLenum gl_error = glGetError();
   if (gl_error) return TCOD_set_errorvf("Unexpected OpenGL error before texture allocation: %u", gl_error);
+  // prospective texture size; start at a minimum of 64x64?
   int new_size = atlas->texture_size ? atlas->texture_size : 64;
+  // get maximum texture size supported by GPU
   int max_size;
   glGetIntegerv(GL_MAX_TEXTURE_SIZE, &max_size);
+  // starting values for tiles per row and per column in the atlas texture
+  // end values may differ because tiles aren't necessarily square in dimension
   int columns = 1;  // Must be more than zero.
   int rows = 1;
+  // calculate a texture size large enough to hold the tileset
   while (1) {
     if (atlas->tileset->tile_width == 0 || atlas->tileset->tile_height == 0) {
       break;  // Avoid division by zero.
     }
-    columns = new_size / atlas->tileset->tile_width;
-    rows = new_size / atlas->tileset->tile_height;
+    // calculate how many rows and colums of tiles can fit in a square texture
+    //  whose dimensions are both new_size
+    // padding around tiles is accounted for by adding to the individual tile
+    //  dimension divisors, while padding around the remaining horizontal and
+    //  vertical edge is accounted for by subtracting from the prospective
+    //  texture size
+    columns = (new_size - TILE_PADDING) / (atlas->tileset->tile_width + TILE_PADDING);
+    rows = (new_size - TILE_PADDING) / (atlas->tileset->tile_height + TILE_PADDING);
     if (rows * columns >= atlas->tileset->tiles_capacity) {
       break;
     }
+    // double the dimensions until texture is large enough to hold the tiles
     new_size *= 2;
   }
   if (new_size > max_size) {
@@ -115,6 +291,7 @@ static int prepare_gl_atlas(struct TCOD_TilesetAtlasOpenGL* atlas) {
       default:
         return TCOD_set_errorvf("OpenGL error while allocating texture atlas: %u", gl_error);
     }
+    // populate atlas with tile data
     for (int i = 0; i < atlas->tileset->tiles_count; ++i) {
       if (upload_gl_tile(atlas, i) < 0) {
         return -1;

--- a/src/libtcod/renderer_gl.h
+++ b/src/libtcod/renderer_gl.h
@@ -36,6 +36,11 @@
 #include "config.h"
 #include "tileset.h"
 
+// tile padding
+// define this as a power of two to include padding around atlas texture glyphs
+// TODO: Update the GL1 renderer to support this
+#define TILE_PADDING 2
+
 struct TCOD_TilesetAtlasOpenGL {
   struct TCOD_Tileset* tileset;  // An owning pointer to tileset, tracks a tilesets character map and other info.
   struct TCOD_TilesetObserver* observer;  // Tracks changes to a tileset.

--- a/src/libtcod/renderer_gl.h
+++ b/src/libtcod/renderer_gl.h
@@ -36,10 +36,10 @@
 #include "config.h"
 #include "tileset.h"
 
-// tile padding
-// define this as a power of two to include padding around atlas texture glyphs
+// optional amount of padding to add around each tile in the atlas texture
+// comment out to disable
 // TODO: Update the GL1 renderer to support this
-#define TILE_PADDING 2
+#define TILE_PADDING 1
 
 struct TCOD_TilesetAtlasOpenGL {
   struct TCOD_Tileset* tileset;  // An owning pointer to tileset, tracks a tilesets character map and other info.

--- a/src/libtcod/renderer_gl2.c
+++ b/src/libtcod/renderer_gl2.c
@@ -216,9 +216,10 @@ static void get_tex_coord(const struct TCOD_TilesetAtlasOpenGL* __restrict atlas
   // get atlas row and column indexes
   int x = tile_id % atlas->texture_columns;
   int y = tile_id / atlas->texture_columns;
-  // now calculate the corresponding atlas pixel coordinates
-  x = TILE_PADDING + (x * (atlas->tileset->tile_width  + TILE_PADDING));
-  y = TILE_PADDING + (y * (atlas->tileset->tile_height + TILE_PADDING));
+  // now calculate the corresponding glyph origin pixel coordinates in the
+  //  atlas texture
+  x = TILE_PADDING + x * (atlas->tileset->tile_width  + 2 * TILE_PADDING);
+  y = TILE_PADDING + y * (atlas->tileset->tile_height + 2 * TILE_PADDING);
   // split 16-bit x and y values into two of 8-bit low and high byte pairs
   out[0] = x & 0xff;
   out[1] = (x >> 8) & 0xff;
@@ -245,9 +246,6 @@ static TCOD_Error render(
     struct TCOD_RendererGL2* __restrict renderer,
     const TCOD_Console* __restrict console,
     const struct TCOD_ViewportOptions* __restrict viewport) {
-// #ifndef TILE_PADDING
-//   const int TILE_PADDING = 0;
-// #endif
   uint8_t* ch_buffer = malloc(sizeof(*ch_buffer) * console->elements * 4);
   TCOD_ColorRGBA* fg_buffer = malloc(sizeof(*fg_buffer) * console->elements);
   TCOD_ColorRGBA* bg_buffer = malloc(sizeof(*bg_buffer) * console->elements);
@@ -291,16 +289,14 @@ static TCOD_Error render(
 
   // Upload data of texture shapes.
   const struct TCOD_TilesetAtlasOpenGL* atlas = renderer->common.atlas;
-
+  //  individual tile pixel dimensions
   float tile_size[2] = {
     (float)atlas->tileset->tile_width,
     (float)atlas->tileset->tile_height,
   };
   glUniform2fv(v_tile_size, 1, tile_size);
+  //  atlas texture pixel dimensions
   float tiles_size[2] = {
-    // pretty sure we just want the actual texture size, which we already have
-    //(float)(TILE_PADDING + atlas->texture_columns * (TILE_PADDING + atlas->tileset->tile_width)),
-    //(float)(TILE_PADDING + atlas->texture_rows    * (TILE_PADDING + atlas->tileset->tile_height))
     (float)(atlas->texture_size),
     (float)(atlas->texture_size)
   };


### PR DESCRIPTION
- CMakeLists.txt:
  - MinGW compat fix
- src/libtcod/renderer_gl.c:
  - implement optional atlas padding support
  - add more comments
- src/libtcod/renderer_gl.h:
  - add optional TILE_PADDING macro to configure atlas padding support
- src/libtcod/renderer_gl2.c:
  - fragment shader: use atlas pixel dimensions instead of row/col index
  - fragment shader: remove clamping logic
  - fragment shader: use texture2DLod to force disable mipmap use
  - encode atlas pixel coordinates in ch buffer texture instead of row/col indexes
  - send actual atlas texture size to fragment shader instead of recalculating