### PR TITLE
Adding rpath current dir for samples to work

### DIFF
--- a/buildsys/scons/SConstruct
+++ b/buildsys/scons/SConstruct
@@ -82,6 +82,7 @@ def samples_factory():
     env_samples.Append(
         CPPPATH=["$VARIANT/src"],
     )
+    env_samples.Append(RPATH=["."])
     if sys.platform != "darwin":
         env_samples.Append(
             LIBS=["SDL2", "SDL2main"],


### PR DESCRIPTION
# Problem
When building with `scons develop_all` or `scons build_all` on a linux system with g++, the resulting Sample executables can not be immediately run because the `libtcod.so` file is not linked in the binary, and is not automatically linked by the dynamic linker. Instead we get an error: `error while loading shared libraries: libtcod.so: cannot open shared object file: No such file or directory`

Youu can see why this is the case by running `ldd sample_cpp` 
 
Notice the `libtcod.so => not found` in the screenshot below.

![Screenshot of commandline showing that the libtcod.so file is not assigned in the binary ](https://github.com/libtcod/libtcod/assets/38126357/570f3a54-3e23-43d2-bc69-515e8e4ded75)

## Solution

Just add `env_samples.Append(RPATH=["."])` to the scons build file when building the sample executable.
This translates to `-Wl,-rpath=.` in the g++ call, and adds the current directory to the "run_path" in the binary.
### Result
Notice the `libtcod.so => ./libtcod.so`
![image](https://github.com/libtcod/libtcod/assets/38126357/52fa59c4-c34e-462d-9669-602a4d58b264)
