### PR TITLE
Fix uninitialized memory in TCODPath and TCODDijkstra

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -97,7 +97,10 @@
         "cfloat": "cpp",
         "ciso646": "cpp",
         "climits": "cpp",
-        "coroutine": "cpp"
+        "coroutine": "cpp",
+        "csignal": "cpp",
+        "ranges": "cpp",
+        "span": "cpp"
     },
     "files.trimFinalNewlines": true,
     "files.insertFinalNewline": true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Versions since `2.0.0` only track API breaks and no longer guarantee ABI compati
 ### Fixed
 - `const` was missing from `TCOD_sys_update_char` image parameter.
 - Prevent key modifiers from getting stuck when the root console is reinitialized.
+- Fixed crash on `TCODPath` and `TCODDijkstra` move operations.
+  [#159](https://github.com/libtcod/libtcod/issues/159)
 
 ## [1.24.0] - 2023-05-26
 ### Added

--- a/src/libtcod/fov.hpp
+++ b/src/libtcod/fov.hpp
@@ -266,7 +266,7 @@ class TCODLIB_API TCODMap {
 		friend class TCODLIB_API TCODPath;
 		friend class TCODLIB_API TCODDijkstra;
 //	protected :
-		TCOD_map_t data;
+		TCOD_map_t data{};
 };
 
 #endif // TCOD_FOV_HPP_

--- a/src/libtcod/lex.hpp
+++ b/src/libtcod/lex.hpp
@@ -37,6 +37,8 @@
 #ifndef TCOD_LEX_HPP_
 #define TCOD_LEX_HPP_
 
+#include <utility>
+
 #include "lex.h"
 
 class TCODLIB_API TCODLex {
@@ -51,6 +53,13 @@ class TCODLIB_API TCODLex {
       const char* javadocCommentStart="/**",
       const char* stringDelim="\"",
       int flags=TCOD_LEX_FLAG_NESTING_COMMENT);
+
+  TCODLex(TCODLex&& rhs) noexcept { std::swap(data, rhs.data); };
+  TCODLex& operator=(TCODLex&& rhs) noexcept {
+    std::swap(data, rhs.data);
+    return *this;
+  };
+
   ~TCODLex();
 
   void setDataBuffer(char* dat);
@@ -114,7 +123,7 @@ class TCODLIB_API TCODLex {
     return TCOD_lex_get_token_name(tokenType);
   }
  protected:
-  TCOD_lex_t* data;
+  TCOD_lex_t* data{};
 };
 #endif // TCOD_LEX_HPP_
 /// @endcond

--- a/src/libtcod/noise.hpp
+++ b/src/libtcod/noise.hpp
@@ -337,7 +337,7 @@ float TCOD_noise_get_turbulence_ex(TCOD_noise_t noise, float *f, float octaves, 
 
 	protected :
 		friend class TCODLIB_API TCODHeightMap;
-		TCOD_noise_t data;
+		TCOD_noise_t data{};
 };
 
 #endif // TCOD_PERLIN_HPP_

--- a/src/libtcod/parser.hpp
+++ b/src/libtcod/parser.hpp
@@ -153,8 +153,11 @@ public :
   // Disable copy operators.
   TCODParser(const TCODParser&) = delete;
   TCODParser& operator=(const TCODParser&) = delete;
-  TCODParser(TCODParser&&) = default;
-  TCODParser& operator=(TCODParser&&) = default;
+  TCODParser(TCODParser&& rhs) noexcept { std::swap(data, rhs.data); };
+  TCODParser& operator=(TCODParser&& rhs) noexcept {
+    std::swap(data, rhs.data);
+    return *this;
+  };
 
 	/**
 	@PageName parser_str
@@ -223,7 +226,7 @@ public :
 	TCOD_list_t getListProperty(const char *name, TCOD_value_type_t type) const;
 private :
 	bool parseEntity(TCODParserStruct *def, ITCODParserListener *listener);
-	TCOD_parser_t data;
+	TCOD_parser_t data{};
 #ifdef _MSC_VER
   // Disable dll-interface warning.  This value should only used internally.
 #pragma warning(push)

--- a/src/libtcod/path.cpp
+++ b/src/libtcod/path.cpp
@@ -31,9 +31,11 @@
  */
 #include "path.hpp"
 
-TCODPath::TCODPath(const TCODMap* map, float diagonalCost) { data = TCOD_path_new_using_map(map->data, diagonalCost); }
+TCODPath::TCODPath(const TCODMap* map, float diagonalCost) : data{TCOD_path_new_using_map(map->data, diagonalCost)} {}
 
-TCODPath::~TCODPath() { TCOD_path_delete(data); }
+TCODPath::~TCODPath() {
+  if (data) TCOD_path_delete(data);
+}
 
 float TCOD_path_func(int xFrom, int yFrom, int xTo, int yTo, void* data) {
   TCODPath::WrapperData* cppData = static_cast<TCODPath::WrapperData*>(data);
@@ -70,7 +72,7 @@ void TCODPath::getDestination(int* x, int* y) const { TCOD_path_get_destination(
 // ----------------- //
 
 // ctor
-TCODDijkstra::TCODDijkstra(TCODMap* map, float diagonalCost) { data = TCOD_dijkstra_new(map->data, diagonalCost); }
+TCODDijkstra::TCODDijkstra(TCODMap* map, float diagonalCost) : data{TCOD_dijkstra_new(map->data, diagonalCost)} {}
 
 // another ctor
 TCODDijkstra::TCODDijkstra(
@@ -81,7 +83,9 @@ TCODDijkstra::TCODDijkstra(
 }
 
 // dtor
-TCODDijkstra::~TCODDijkstra(void) { TCOD_dijkstra_delete(data); }
+TCODDijkstra::~TCODDijkstra(void) {
+  if (data) TCOD_dijkstra_delete(data);
+}
 
 // compute distances grid
 void TCODDijkstra::compute(int rootX, int rootY) { TCOD_dijkstra_compute(data, rootX, rootY); }

--- a/src/libtcod/path.hpp
+++ b/src/libtcod/path.hpp
@@ -169,11 +169,11 @@ public :
   TCODPath& operator=(const TCODPath&) = delete;
   TCODPath(TCODPath&& rhs) noexcept {
     std::swap(data, rhs.data);
-    cppData = std::move(rhs.cppData);
+    std::swap(cppData, rhs.cppData);
   }
   TCODPath& operator=(TCODPath&& rhs) noexcept {
     std::swap(data, rhs.data);
-    cppData = std::move(rhs.cppData);
+    std::swap(cppData, rhs.cppData);
     return *this;
   }
 	/**
@@ -485,10 +485,10 @@ public :
 
 protected :
 	friend float TCOD_path_func(int xFrom, int yFrom, int xTo,int yTo, void *data);
-	TCOD_path_t data;
+	TCOD_path_t data{};
 	struct WrapperData {
-		void *userData;
-		const ITCODPathCallback *listener;
+		void *userData{};
+		const ITCODPathCallback *listener{};
 	} cppData;
 };
 
@@ -502,11 +502,11 @@ class TCODLIB_API TCODDijkstra {
         TCODDijkstra& operator=(const TCODDijkstra&) = delete;
         TCODDijkstra(TCODDijkstra&& rhs) noexcept {
           std::swap(data, rhs.data);
-          cppData = std::move(rhs.cppData);
+          std::swap(cppData, rhs.cppData);
         }
-        TCODDijkstra& operator=(TCODDijkstra&& rhs)noexcept {
+        TCODDijkstra& operator=(TCODDijkstra&& rhs) noexcept {
           std::swap(data, rhs.data);
-          cppData = std::move(rhs.cppData);
+          std::swap(cppData, rhs.cppData);
           return *this;
         }
 
@@ -576,10 +576,10 @@ class TCODLIB_API TCODDijkstra {
 		int size() const;
 		void get(int index, int *x, int *y) const;
     private:
-        TCOD_dijkstra_t data;
+        TCOD_dijkstra_t data{};
         struct WrapperData {
-            void *userData;
-            const ITCODPathCallback *listener;
+            void *userData{};
+            const ITCODPathCallback *listener{};
         } cppData;
 };
 

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -319,3 +319,14 @@ TEST_CASE("FOV Benchmarks", "[.benchmark]") {
     };
   }
 }
+
+TEST_CASE("TCODPath move") {
+  {
+    auto path_inital = TCODPath(1, 1, nullptr, nullptr);
+    auto path_moved = TCODPath{std::move(path_inital)};
+  }
+  {
+    auto path_inital = TCODDijkstra(1, 1, nullptr, nullptr);
+    auto path_moved = TCODDijkstra{std::move(path_inital)};
+  }
+}


### PR DESCRIPTION
Initialize memory by default so that swap operations are valid, used by move

Test move for TCODPath

Fixes https://github.com/libtcod/libtcod/issues/159

Also updated similar classes with uninitialized memory.