### PR TITLE
Fix Android NDK r27 build

### DIFF
--- a/src/libtcod/sys_sdl_img_png.c
+++ b/src/libtcod/sys_sdl_img_png.c
@@ -32,7 +32,7 @@
 #include "sys.h"
 #ifndef NO_SDL
 #ifndef TCOD_NO_PNG
-#if !defined(__HAIKU__) && !defined(__ANDROID__)
+#if !defined(__HAIKU__)
 #include <stdio.h>
 #include <stdlib.h>
 #endif


### PR DESCRIPTION
Resolves: https://github.com/libtcod/libtcod/issues/163
Fix Android NDK r27 build by allowing to include stdlib.h so it would resolve  C:/Users/Admin/AppData/Local/.xmake/cache/packages/2506/l/libtcod/2.1.1/source/src/libtcod/sys_sdl_img_png.c:65:5: error: call to undeclared library function 'free' with type 'void (void *)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   65 |     free(png);