### PR TITLE
Fix COmpilation on GLIBC 2.42 by renaming B10000000 to BB10000000.

### DIFF
--- a/src/libtcod/renderer_xterm.c
+++ b/src/libtcod/renderer_xterm.c
@@ -93,7 +93,7 @@ struct TCOD_RendererXterm {
 };
 
 static char* ucs4_to_utf8(int ucs4, char out[5]) {
-  static const unsigned char B10000000 = 128;
+  static const unsigned char BB10000000 = 128;
   static const unsigned char B11000000 = 192;
   static const unsigned char B11100000 = 224;
   static const unsigned char B11110000 = 240;
@@ -110,20 +110,20 @@ static char* ucs4_to_utf8(int ucs4, char out[5]) {
     return out;
   } else if (ucs4 <= 0x07FF) {
     out[0] = B11000000 | (unsigned char)((ucs4 & B000_000000_011111_000000) >> 6);
-    out[1] = B10000000 | (unsigned char)((ucs4 & B000_000000_000000_111111) >> 0);
+    out[1] = BB10000000 | (unsigned char)((ucs4 & B000_000000_000000_111111) >> 0);
     out[2] = '\0';
     return out;
   } else if (ucs4 <= 0xFFFF) {
     out[0] = B11100000 | (unsigned char)((ucs4 & B000_001111_000000_000000) >> 12);
-    out[1] = B10000000 | (unsigned char)((ucs4 & B000_000000_111111_000000) >> 6);
-    out[2] = B10000000 | (unsigned char)((ucs4 & B000_000000_000000_111111) >> 0);
+    out[1] = BB10000000 | (unsigned char)((ucs4 & B000_000000_111111_000000) >> 6);
+    out[2] = BB10000000 | (unsigned char)((ucs4 & B000_000000_000000_111111) >> 0);
     out[3] = '\0';
     return out;
   } else if (ucs4 <= 0x10FFFF) {
     out[0] = B11110000 | (unsigned char)((ucs4 & B111_000000_000000_000000) >> 18);
-    out[1] = B10000000 | (unsigned char)((ucs4 & B000_111111_000000_000000) >> 12);
-    out[2] = B10000000 | (unsigned char)((ucs4 & B000_000000_111111_000000) >> 6);
-    out[3] = B10000000 | (unsigned char)((ucs4 & B000_000000_000000_111111) >> 0);
+    out[1] = BB10000000 | (unsigned char)((ucs4 & B000_111111_000000_000000) >> 12);
+    out[2] = BB10000000 | (unsigned char)((ucs4 & B000_000000_111111_000000) >> 6);
+    out[3] = BB10000000 | (unsigned char)((ucs4 & B000_000000_000000_111111) >> 0);
     out[4] = '\0';
     return out;
   }


### PR DESCRIPTION
This pr fixes a bug on GLIBC 2.42 that prevents compilation by renaming the variable in question.

**Describe the bug**
GLIBC 2.42 introduced a change in the termios.h interface that added this line to termios-baud.h:
`#define B10000000     10000000U`
This causes compilation to fail because when libtcod attempts to define the name, it exists already:
```
FAILED: subprojects/libtcod/liblibtcod.a.p/src_libtcod_renderer_xterm.c.o                                                                                                                                                     
cc -Isubprojects/libtcod/liblibtcod.a.p -Isubprojects/libtcod -I../subprojects/libtcod -I../subprojects/libtcod/src/vendor -I../subprojects/libtcod/src/vendor/utf8proc -I../subprojects/libtcod/src -I/usr/include -fdiagnost
ics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Wpedantic -O0 -g -g -fvisibility=hidden -DLIBTCOD_STATIC -DTCOD_IGNORE_DEPRECATED -MD -MQ subprojects/libtcod/liblibtcod.a.p/src_libtcod_renderer_xterm.c
.o -MF subprojects/libtcod/liblibtcod.a.p/src_libtcod_renderer_xterm.c.o.d -o subprojects/libtcod/liblibtcod.a.p/src_libtcod_renderer_xterm.c.o -c ../subprojects/libtcod/src/libtcod/renderer_xterm.c                        
In file included from /usr/include/bits/termios.h:84,                                                                                                                                                                         
                 from /usr/include/termios.h:39,                                                                                                                                                                              
                 from ../subprojects/libtcod/src/libtcod/renderer_xterm.c:46:                                                                                                                                                 
../subprojects/libtcod/src/libtcod/renderer_xterm.c: In function ‘ucs4_to_utf8’:                                                                                                                                              
../subprojects/libtcod/src/libtcod/renderer_xterm.c:96:30: error: expected identifier or ‘(’ before numeric constant                                                                                                          
   96 |   static const unsigned char B10000000 = 128;                                                                                                                                                                         
      |                              ^~~~~~~~~
```

**To Reproduce**
Attempt to compile on a GNU/Linux environment with GLIBC 2.42.

**Expected behavior**
Libtcod compiles without issues.

**Environment (please complete the following information):**
 - Platform: Arch Linux
 - Libtcod version: 2.1.1
 - Libtcod source: Git pull at tag 2.1.1
 - Compiler used: GCC 15.1.1, GLIBC 2.42

**Additional context**
GLIBC 2.42 was released on 2025-07-28. Libtcod compiled just fine before then.