### PR TITLE
FOV Memory Safety

### DIFF
--- a/src/libtcod/fov_permissive2.c
+++ b/src/libtcod/fov_permissive2.c
@@ -93,9 +93,9 @@ static void view_array_remove(ActiveViewArray* view_array, ptrdiff_t index) {
 
 /// @brief Insert a view into the active views array.
 static void view_array_insert(ActiveViewArray* view_array, ptrdiff_t index, View* view_ptr) {
-  ++view_array->count;
-  for (ptrdiff_t i = view_array->count - 1; i >= index; --i) view_array->view_ptrs[i + 1] = view_array->view_ptrs[i];
+  for (ptrdiff_t i = view_array->count; i > index; --i) view_array->view_ptrs[i] = view_array->view_ptrs[i - 1];
   view_array->view_ptrs[index] = view_ptr;
+  ++view_array->count;
 }
 
 /// @brief Return a past-the-end pointer for the active view array.

--- a/src/libtcod/fov_permissive2.c
+++ b/src/libtcod/fov_permissive2.c
@@ -298,7 +298,8 @@ TCOD_Error TCOD_map_compute_fov_permissive2(
 
   // Preallocate views and bumps, assuming there will be no more bumps or active views than the number of map tiles.
   View* views = malloc(map->width * map->height * sizeof(*views));
-  ViewBumpContainer bumps = {.data = malloc(map->width * map->height * sizeof(*bumps.data))};
+  const int bump_cap = TCOD_MAX(map->nbcells, 16);  // maps <= 6 cells can overflow, minimum of 16 for memory safety
+  ViewBumpContainer bumps = {.data = malloc(bump_cap * sizeof(*bumps.data))};
   ActiveViewArray active_views = {.view_ptrs = malloc(map->width * map->height * sizeof(*active_views.view_ptrs))};
   if (!views || !bumps.data || !active_views.view_ptrs) {
     free(bumps.data);

--- a/src/libtcod/fov_restrictive.c
+++ b/src/libtcod/fov_restrictive.c
@@ -244,7 +244,7 @@ TCOD_Error TCOD_map_compute_fov_restrictive_shadowcasting(
   map->cells[pov_x + (pov_y * map->width)].fov = true;
 
   /* calculate an approximated (excessive, just in case) maximum number of obstacles per octant */
-  const int max_obstacles = map->nbcells / 7;
+  const int max_obstacles = TCOD_MAX(map->nbcells / 7, 16);
   double* start_angle = malloc(max_obstacles * sizeof(*start_angle));
   double* end_angle = malloc(max_obstacles * sizeof(*end_angle));
   if (!start_angle || !end_angle) {

--- a/tests/test_fov.cpp
+++ b/tests/test_fov.cpp
@@ -1,0 +1,105 @@
+#include <libtcod/fov.h>
+
+#include <catch2/catch_all.hpp>
+#include <utility>
+#include <vector>
+
+// Regression for the view_array_insert off-by-one: it writes one past the
+// active_views buffer (sized width*height). The only trigger is a 2x2 map at
+// FOV_PERMISSIVE_8; under AddressSanitizer this aborts before the fix.
+TEST_CASE("permissive FOV does not overflow active_views on tiny maps", "[fov]") {
+  for (int w = 1; w <= 3; ++w)
+    for (int h = 1; h <= 3; ++h)
+      for (int pov = 0; pov < w * h; ++pov) {
+        TCOD_Map* map = TCOD_map_new(w, h);
+        TCOD_map_clear(map, false, true);  // every cell opaque
+        CHECK(TCOD_map_compute_fov(map, pov % w, pov / w, 0, true, FOV_PERMISSIVE_8) == TCOD_E_OK);
+        TCOD_map_delete(map);
+      }
+}
+
+// Regression for the undersized per-quadrant `bumps` buffer (sized width*height).
+// Reproduced on 2x3 / 3x2 maps, which never reach the active-view count that
+// triggers bug #1, so this isolates the bumps overflow. ASan aborts pre-fix.
+TEST_CASE("permissive FOV does not overflow bumps on tiny maps", "[fov]") {
+  const int dims[][2] = {{2, 3}, {3, 2}};
+  for (const auto& d : dims) {
+    const int n = d[0] * d[1];
+    for (int pattern = 0; pattern < (1 << n); ++pattern)
+      for (int pov = 0; pov < n; ++pov) {
+        if (pattern & (1 << pov)) continue;
+        for (int light_walls = 0; light_walls <= 1; ++light_walls) {
+          TCOD_Map* map = TCOD_map_new(d[0], d[1]);
+          TCOD_map_clear(map, true, true);
+          for (int i = 0; i < n; ++i)
+            if (pattern & (1 << i)) TCOD_map_set_properties(map, i % d[0], i / d[0], false, true);
+          CHECK(TCOD_map_compute_fov(map, pov % d[0], pov / d[0], 0, (bool)light_walls, FOV_PERMISSIVE_8) == TCOD_E_OK);
+          TCOD_map_delete(map);
+        }
+      }
+  }
+}
+
+// Regression for the undersized obstacle buffer in MRPAS restrictive FOV
+// (TCOD_map_compute_fov_restrictive_shadowcasting). Its angle buffers are sized
+// `max_obstacles = nbcells / 7`, which floors below the true per-quadrant
+// obstacle count on small maps; the scan then writes one obstacle past the end
+// of start_angle / end_angle -- always a single 8-byte (one double) overrun.
+// Unpatched, AddressSanitizer aborts at fov_restrictive.c compute_quadrant.
+
+// Part 1 -- exhaustive sweep of small maps: every wall pattern x every POV x
+// both light_walls settings. Each of these shapes overflows pre-fix (peak
+// obstacles = nbcells/7 + 1). Includes non-square shapes (2x6, 3x4) to show the
+// bug is not limited to squares.
+TEST_CASE("restrictive FOV: small-map obstacle overflow (exhaustive)", "[fov]") {
+  const int dims[][2] = {{2, 2}, {2, 3}, {3, 2}, {3, 3}, {2, 6}, {3, 4}, {4, 4}};
+  for (const auto& d : dims) {
+    const int w = d[0], h = d[1], n = w * h;
+    for (long pattern = 0; pattern < (1L << n); ++pattern)
+      for (int pov = 0; pov < n; ++pov) {
+        if (pattern & (1L << pov)) continue;
+        for (int light_walls = 0; light_walls <= 1; ++light_walls) {
+          TCOD_Map* map = TCOD_map_new(w, h);
+          TCOD_map_clear(map, true, true);
+          for (int i = 0; i < n; ++i)
+            if (pattern & (1L << i)) TCOD_map_set_properties(map, i % w, i / w, false, true);
+          CHECK(TCOD_map_compute_fov(map, pov % w, pov / w, 0, (bool)light_walls, FOV_RESTRICTIVE) == TCOD_E_OK);
+          TCOD_map_delete(map);
+        }
+      }
+  }
+}
+
+// Part 2 -- the overflow envelope is shape-dependent, not a 5x5 box. The peak
+// obstacle count saturates with the map's smaller dimension while nbcells/7
+// grows with area, so each width has a band of heights that overflow. Exhaustive
+// search is infeasible past ~16 cells (2^25+ patterns), so these are concrete
+// adversarial layouts -- the largest overflowing shape per width -- found by a
+// peak-obstacle search and verified to overflow the unpatched library. The
+// largest is 4x8 (32 cells): a 5th obstacle written into a 4-slot (32-byte)
+// buffer. All use light_walls=true and an unbounded radius (0).
+namespace {
+struct Layout {
+  const char* name;
+  int w, h, pov_x, pov_y;
+  std::vector<std::pair<int, int>> walls;
+};
+}  // namespace
+
+TEST_CASE("restrictive FOV: larger non-square overflow envelope", "[fov][bug3]") {
+  const std::vector<Layout> layouts = {
+      {"5x5", 5, 5, 0, 4, {{0, 0}, {3, 0}, {4, 0}, {1, 1}, {2, 1}, {4, 1}, {1, 2}, {4, 2}, {0, 3}, {4, 3}}},
+      {"3x8", 3, 8, 2, 0, {{1, 0}, {0, 1}, {0, 2}, {0, 4}, {0, 7}, {1, 7}}},
+      {"4x6", 4, 6, 3, 0, {{0, 0}, {0, 1}, {1, 1}, {1, 2}, {0, 5}, {1, 5}, {2, 5}}},
+      {"3x9", 3, 9, 2, 7, {{0, 0}, {1, 0}, {0, 3}, {0, 5}, {0, 7}, {1, 7}, {2, 8}}},
+      {"4x8", 4, 8, 0, 7, {{1, 0}, {2, 0}, {3, 0}, {3, 2}, {3, 4}, {3, 6}, {2, 7}}},
+  };
+  for (const auto& L : layouts) {
+    CAPTURE(L.name);
+    TCOD_Map* map = TCOD_map_new(L.w, L.h);
+    TCOD_map_clear(map, true, true);
+    for (const auto& wall : L.walls) TCOD_map_set_properties(map, wall.first, wall.second, false, true);
+    CHECK(TCOD_map_compute_fov(map, L.pov_x, L.pov_y, 0, true, FOV_RESTRICTIVE) == TCOD_E_OK);
+    TCOD_map_delete(map);
+  }
+}


### PR DESCRIPTION
Greetings, this PR is for a few memory safety issues related to FOV on small TCOD maps. These issues were discovered while fuzzing McRogueFace's public API, and some of the results were inside libtcod.

## Replication

 New tests in a new test file for FOV. ( 0527c28dbd4af26daba9215404ef94e68ab5a892 )

The test suite will always encounter a segfault on these tests, but more detail is available with address sanitizer (ASan) enabled. The results:

```
######## TEST: permissive FOV does not overflow active_views on tiny maps
==3495182==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x603000001ec0 at pc 0x55d55e207132 bp
0x7ffef41dcc90 sp 0x7ffef41dcc88
    #0 0x55d55e207131 in view_array_insert /home/john/Development/libtcod/src/libtcod/fov_permissive2.c:97
    #1 0x55d55e208223 in visit_coords /home/john/Development/libtcod/src/libtcod/fov_permissive2.c:219
    #2 0x55d55e208847 in check_quadrant /home/john/Development/libtcod/src/libtcod/fov_permissive2.c:276
    #3 0x55d55e208ed7 in TCOD_map_compute_fov_permissive2
/home/john/Development/libtcod/src/libtcod/fov_permissive2.c:322
    #4 0x55d55e2038ee in TCOD_map_compute_fov /home/john/Development/libtcod/src/libtcod/fov_c.c:196
>>> exit code: 134

######## TEST: permissive FOV does not overflow bumps on tiny maps
==3495196==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x608000005c00 at pc 0x55cb2be8950c bp
0x7ffd3a19d330 sp 0x7ffd3a19d328
    #0 0x55cb2be8950b in add_shallow_bump /home/john/Development/libtcod/src/libtcod/fov_permissive2.c:120
    #1 0x55cb2be89f3b in visit_coords /home/john/Development/libtcod/src/libtcod/fov_permissive2.c:205
    #2 0x55cb2be8a847 in check_quadrant /home/john/Development/libtcod/src/libtcod/fov_permissive2.c:276
    #3 0x55cb2be8afa1 in TCOD_map_compute_fov_permissive2
/home/john/Development/libtcod/src/libtcod/fov_permissive2.c:324
    #4 0x55cb2be858ee in TCOD_map_compute_fov /home/john/Development/libtcod/src/libtcod/fov_c.c:196
>>> exit code: 134

######## TEST: restrictive FOV: small-map obstacle overflow (exhaustive)
==3495210==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x602000001530 at pc 0x55e86411461e bp
0x7ffeea2010d0 sp 0x7ffeea2010c8
    #0 0x55e86411461d in compute_quadrant /home/john/Development/libtcod/src/libtcod/fov_restrictive.c:121
    #1 0x55e8641155f2 in TCOD_map_compute_fov_restrictive_shadowcasting
/home/john/Development/libtcod/src/libtcod/fov_restrictive.c:260
    #2 0x55e86410d90c in TCOD_map_compute_fov /home/john/Development/libtcod/src/libtcod/fov_c.c:198
    #3 0x55e8640a0bcd in CATCH2_INTERNAL_TEST_4 /home/john/Development/libtcod/tests/test_fov.cpp:66
    #1 0x55e8641154b8 in TCOD_map_compute_fov_restrictive_shadowcasting
/home/john/Development/libtcod/src/libtcod/fov_restrictive.c:248
>>> exit code: 134

######## TEST: restrictive FOV: larger non-square overflow envelope
==3495226==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x603000001c48 at pc 0x562ef4e7d189 bp
0x7ffc8db82bb0 sp 0x7ffc8db82ba8
    #0 0x562ef4e7d188 in compute_quadrant /home/john/Development/libtcod/src/libtcod/fov_restrictive.c:214
    #1 0x562ef4e7d58e in TCOD_map_compute_fov_restrictive_shadowcasting
/home/john/Development/libtcod/src/libtcod/fov_restrictive.c:258
    #2 0x562ef4e7590c in TCOD_map_compute_fov /home/john/Development/libtcod/src/libtcod/fov_c.c:198
    #3 0x562ef4e0b2c3 in CATCH2_INTERNAL_TEST_6 /home/john/Development/libtcod/tests/test_fov.cpp:102
    #1 0x562ef4e7d4b8 in TCOD_map_compute_fov_restrictive_shadowcasting
/home/john/Development/libtcod/src/libtcod/fov_restrictive.c:248
>>> exit code: 134
```

## Bug 1 - permissive FOV `view_array_insert` off-by-one
While the active-view count stays below capacity that stray write lands on an unused slot, so normal maps work. On
a 2x2 map the count reaches `W*H` and it writes beyond the buffer.

Fix: shift from the current end and increment `count` last. ( 0455801d5d3cc3bca7c66d7814bf15fe5c276d59 )

## Bug 2 - permissive `bumps` buffer undersized
the view-split branch appends two entries per visited cell, so the worst case is `~2*W*H`, but the buffer is `W*H`. In practice the peak is a small constant, so `W*H` only falls short on maps smaller than 3x3.

Fix: minimum buffer size of 16. ( 82106481ae06ce9cc3c65fbbd8168b45d2540f44 )

## Bugs 3 + 4 - restrictive obstacle buffer undersized
For any map under 7 cells this is `0` (`malloc(0)`), and the first recorded obstacle overflows. More generally, a single quadrant can record one obstacle more than `floor(nbcells/7)` provisions on some maps of size 4x8 or smaller.

Fix: Minimum buffer size of 16. ( eaf2d5bd3f06a640cb10858937f5f0d4ae05dddc )

---

Thank you for considering my PR.